### PR TITLE
Bugfixes for v0.6.0

### DIFF
--- a/asn1editor/wxPython/FilePickerHandler.py
+++ b/asn1editor/wxPython/FilePickerHandler.py
@@ -28,7 +28,11 @@ class FilePickerHandler:
                 filenames = [file_dialog.GetPath()]
             except TypeError:
                 filenames = [file_dialog.GetPath()]
-            Environment.settings[file_dialog.GetMessage()] = os.path.dirname(filenames[0])
+            if os.path.isdir(filenames[0]):
+                path = filenames[0]
+            else:
+                path = os.path.dirname(filenames[0])
+            Environment.settings[file_dialog.GetMessage()] = path
             filenames = filenames if len(filenames) > 1 else filenames[0]
             self.file_selected(filenames, file_dialog.GetParent())
 

--- a/asn1editor/wxPython/SingleFileDropTarget.py
+++ b/asn1editor/wxPython/SingleFileDropTarget.py
@@ -11,6 +11,6 @@ class SingleFileDropTarget(wx.FileDropTarget):
 
     def OnDropFiles(self, _, __, filenames):
         if len(filenames) == 1:
-            self.__callback(filenames[0])
+            wx.CallAfter(self.__callback, filenames[0])
             return True
         return False

--- a/asn1editor/wxPython/TreeView.py
+++ b/asn1editor/wxPython/TreeView.py
@@ -125,7 +125,7 @@ class TreeView:
         menu.Bind(wx.EVT_MENU, lambda _: self.__tree_ctrl.ExpandAllChildren(e.GetItem()), menu.expand)
         menu.Bind(wx.EVT_MENU, lambda _: self.__tree_ctrl.ExpandAll(), menu.expand_all)
         menu.Bind(wx.EVT_MENU, lambda _: self.__tree_ctrl.CollapseAllChildren(e.GetItem()), menu.collapse)
-        menu.Bind(wx.EVT_MENU, lambda _: self.__tree_ctrl.CollapseAll(), menu.collapse_all)
+        menu.Bind(wx.EVT_MENU, lambda _: (self.__tree_ctrl.CollapseAll(), self.__show_view(None)), menu.collapse_all)
         self.__tree_ctrl.GetTopLevelParent().PopupMenu(menu, e.GetPoint())
 
     def __show_view(self, view: typing.Optional[WxPythonView]):


### PR DESCRIPTION
Fixes #31: Show empty view when collapsing all tree elements
Fixes #29: Drop event is processed before the reaction is executed
Fixes #30: Properly saving last opened directory in DirDialog 