### PR TITLE
Tree right click fix

### DIFF
--- a/asn1editor/wxPython/TreeView.py
+++ b/asn1editor/wxPython/TreeView.py
@@ -126,7 +126,8 @@ class TreeView:
         menu = RightClickMenu(self.__tree_ctrl.GetTopLevelParent())
         menu.Bind(wx.EVT_MENU, lambda _: self.__tree_ctrl.ExpandAllChildren(e.GetItem()), menu.expand)
         menu.Bind(wx.EVT_MENU, lambda _: self.__tree_ctrl.ExpandAll(), menu.expand_all)
-        menu.Bind(wx.EVT_MENU, lambda _: self.__tree_ctrl.CollapseAllChildren(e.GetItem()), menu.collapse)
+        menu.Bind(wx.EVT_MENU, lambda _: (self.__tree_ctrl.CollapseAllChildren(e.GetItem()),
+                                          self.__show_view(self.__tree_ctrl.GetItemData(self.__tree_ctrl.GetSelection()))), menu.collapse)
         menu.Bind(wx.EVT_MENU, lambda _: (self.__tree_ctrl.CollapseAll(), self.__show_view(None)), menu.collapse_all)
         self.__tree_ctrl.GetTopLevelParent().PopupMenu(menu, e.GetPoint())
 

--- a/asn1editor/wxPython/TreeView.py
+++ b/asn1editor/wxPython/TreeView.py
@@ -121,6 +121,8 @@ class TreeView:
                 self.collapse = self.Append(wx.NewId(), 'Collapse')
                 self.collapse_all = self.Append(wx.NewId(), 'Collapse all')
 
+        self.item_selected(e)
+
         menu = RightClickMenu(self.__tree_ctrl.GetTopLevelParent())
         menu.Bind(wx.EVT_MENU, lambda _: self.__tree_ctrl.ExpandAllChildren(e.GetItem()), menu.expand)
         menu.Bind(wx.EVT_MENU, lambda _: self.__tree_ctrl.ExpandAll(), menu.expand_all)


### PR DESCRIPTION
Fixes #33: When right clicking a tree element, its content is displayed
Collapsing an element now makes sure that the selection matches the content panel

